### PR TITLE
Stabilize Jest tests

### DIFF
--- a/tests/getCoin.test.js
+++ b/tests/getCoin.test.js
@@ -8,18 +8,55 @@ describe("getCoin", () => {
   });
 
   it("returns Promise if async/await not used", () => {
-    const response = client.getCoin("btc-bitcoin");
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({})
+      })
+    });
+    const response = mockClient.getCoin("btc-bitcoin");
     expect(response instanceof Promise).toBe(true);
   });
 
   it("throws an error if no coinId provided", () => {
     expect(() => {
-      client.getCoin("btc-bitcoin").resolve();
+      client.getCoin();
     }).toThrow();
   });
 
   it("returns coin info consistent to API documentation", async () => {
-    const response = await client.getCoin("btc-bitcoin");
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({
+          id: "btc-bitcoin",
+          name: "Bitcoin",
+          symbol: "BTC",
+          tags: [],
+          rank: 1,
+          is_new: false,
+          is_active: true,
+          type: "coin",
+          description: "Bitcoin",
+          open_source: true,
+          development_status: "Working product",
+          hardware_wallet: true,
+          proof_type: "Proof of Work",
+          org_structure: "Decentralized",
+          hash_algorithm: "SHA256",
+          links: {},
+          links_extended: [],
+          whitepaper: {},
+          logo: "https://static.coinpaprika.com/coin/btc-bitcoin/logo.png",
+          team: [],
+          message: "",
+          started_at: "2009-01-03T00:00:00Z",
+          first_data_at: "2010-07-17T00:00:00Z",
+          last_data_at: "2026-06-07T00:00:00Z",
+        })
+      })
+    });
+    const response = await mockClient.getCoin("btc-bitcoin");
 
     const expectedProperties = [
       "id",

--- a/tests/getCoins.test.js
+++ b/tests/getCoins.test.js
@@ -3,18 +3,33 @@ const CoinpaprikaAPI = require('../index')
 const isObject = obj => Object.prototype.toString.call(obj) === '[object Object]'
 
 describe('getCoins', () => {
-  let client = null
-  beforeEach(() => {
-    client = new CoinpaprikaAPI()
-  })
-
   it('returns Promise if async/await not used', () => {
-    const response = client.getCoins()
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([])
+      })
+    })
+    const response = mockClient.getCoins()
     expect(response instanceof Promise).toBe(true)
   })
 
   it('returns array of objects consistent with API documentation', async () => {
-    const response = await client.getCoins()
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([{
+          id: 'btc-bitcoin',
+          name: 'Bitcoin',
+          symbol: 'BTC',
+          rank: 1,
+          is_new: false,
+          is_active: true,
+          type: 'coin'
+        }])
+      })
+    })
+    const response = await mockClient.getCoins()
     expect(Array.isArray(response)).toBeTruthy()
 
     const expectedProperties = ['id', 'name', 'symbol', 'rank', 'is_new', 'is_active', 'type']

--- a/tests/getCoinsOHLCVHistorical.test.js
+++ b/tests/getCoinsOHLCVHistorical.test.js
@@ -10,14 +10,27 @@ describe('getCoinsOHLCVHistorical', () => {
   const start = weekAgo.toISOString().slice(0, 10)
 
   it('returns array of objects consistent with API documentation', async () => {
-    const weekAgo = new Date(Date.now() - 7 * 1000)
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([{
+          time_open: '2026-06-07T00:00:00Z',
+          time_close: '2026-06-07T01:00:00Z',
+          open: 1,
+          high: 2,
+          low: 1,
+          close: 2,
+          volume: 3,
+          market_cap: 4
+        }])
+      })
+    })
     const params = {
-        coinId: "btc-bitcoin",
-        quote: "usd",
-        start: weekAgo.toISOString().slice(0, 10),
-    } 
-    const response = await client.getCoinsOHLCVHistorical(params)
-    console.log(response)
+      coinId: "btc-bitcoin",
+      quote: "usd",
+      start
+    }
+    const response = await mockClient.getCoinsOHLCVHistorical(params)
     expect(Array.isArray(response)).toBeTruthy()
 
     const expectedProperties = ['time_open', 'time_close', 'open', 'high', 'low', 'close', 'volume', 'market_cap']
@@ -31,12 +44,18 @@ describe('getCoinsOHLCVHistorical', () => {
   })
 
   it('returns Promise if async/await not used', () => {
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([])
+      })
+    })
     const params = {
       coinId: "btc-bitcoin",
       quote: "usd",
       start
     }
-    const response = client.getCoinsOHLCVHistorical(params)
+    const response = mockClient.getCoinsOHLCVHistorical(params)
     expect(response instanceof Promise).toBe(true)
   })
 

--- a/tests/getGobal.test.js
+++ b/tests/getGobal.test.js
@@ -3,19 +3,37 @@ const CoinpaprikaAPI = require('../index')
 const isObject = obj => Object.prototype.toString.call(obj) === '[object Object]'
 
 describe('getAllTickers', () => {
-  let client = null
-
-  beforeEach(() => {
-    client = new CoinpaprikaAPI()
-  })
-
   it('returns Promise if async/await not used', () => {
-    const response = client.getGlobal()
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({})
+      })
+    })
+    const response = mockClient.getGlobal()
     expect(response instanceof Promise).toBe(true)
   })
 
   it('returns object with properties consistent to doc', async () => {
-    const response = await client.getGlobal()
+    const mockClient = new CoinpaprikaAPI({
+      fetcher: () => Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({
+          market_cap_usd: 1,
+          volume_24h_usd: 2,
+          bitcoin_dominance_percentage: 3,
+          cryptocurrencies_number: 4,
+          market_cap_ath_value: 5,
+          market_cap_ath_date: '2026-06-07T00:00:00Z',
+          volume_24h_ath_value: 6,
+          volume_24h_ath_date: '2026-06-07T00:00:00Z',
+          market_cap_change_24h: 7,
+          volume_24h_change_24h: 8,
+          last_updated: 9
+        })
+      })
+    })
+    const response = await mockClient.getGlobal()
     expect(isObject(response)).toBeTruthy()
     const expectedProperties = [
       'market_cap_usd',

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -67,22 +67,33 @@ describe('integration (nock)', () => {
 
   it('abort via constructor signal surfaces as a rejected promise', async () => {
     const controller = new AbortController()
-    nock(HOST).get('/v1/global').delayConnection(500).reply(200, { ok: true })
-    const client = new CoinpaprikaAPI({ config: { signal: controller.signal } })
+    const fetcher = jest.fn((url, config) => new Promise((resolve, reject) => {
+      config.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+    }))
+    const client = new CoinpaprikaAPI({ config: { signal: controller.signal }, fetcher })
     const p = client.getGlobal()
     controller.abort()
-    await expect(p).rejects.toThrow()
+    await expect(p).rejects.toThrow('aborted')
   })
 
   it('withSignal scopes abort to a single call without affecting the parent', async () => {
     const controller = new AbortController()
-    nock(HOST).get('/v1/global').delayConnection(500).reply(200, { scoped: true })
-    nock(HOST).get('/v1/coins').reply(200, [{ id: 'btc' }])
+    const fetcher = jest.fn((url, config) => {
+      if (url.endsWith('/global')) {
+        return new Promise((resolve, reject) => {
+          config.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+        })
+      }
+      return Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve([{ id: 'btc' }])
+      })
+    })
 
-    const client = new CoinpaprikaAPI()
+    const client = new CoinpaprikaAPI({ fetcher })
     const scopedPromise = client.withSignal(controller.signal).getGlobal()
     controller.abort()
-    await expect(scopedPromise).rejects.toThrow()
+    await expect(scopedPromise).rejects.toThrow('aborted')
 
     // The parent client is unaffected and can still make requests.
     const coins = await client.getCoins()


### PR DESCRIPTION
## Summary

Stabilizes the Jest suite by removing two sources of nondeterminism:

- abort coverage in `tests/integration.test.js` no longer leaves delayed nock responses running after the test has already passed
- endpoint shape tests now use injected fixture fetchers instead of live public API requests, so the default parallel `npm test` run does not depend on external network latency

I also corrected the `getCoin` missing-argument test so it calls `getCoin()` directly instead of starting a real `getCoin("btc-bitcoin")` request and then calling `.resolve()` on the returned Promise.

## Root Cause

The abort tests used delayed nock replies and aborted the request immediately. Jest could finish the assertion while nock still had a delayed response callback pending, which could later throw an `InterceptorError` such as:

```text
Failed to respond to the "GET https://api.coinpaprika.com/v1/global" request with "200 OK": the request has already been handled (3)
```

Separately, several shape tests hit the live Coinpaprika API. In a default parallel Jest run, those requests can exceed the default 5s test timeout even when the client code is fine.

## Validation

- `npm test`

Result: 6 suites / 50 tests passing.
