### PR TITLE
docs(readme): replace dead Travis CI badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Coinpaprika API NodeJS Client
 
 <span class="badge-npmversion"><a href="https://www.npmjs.com/package/@coinpaprika/api-nodejs-client" title="View this project on NPM"><img src="https://img.shields.io/npm/v/@coinpaprika/api-nodejs-client.svg" alt="NPM version" /></a></span>
-<span class="badge-travisci"><a href="http://travis-ci.org/bevry/badges" title="Check this project's build status on TravisCI"><img src="https://img.shields.io/travis/coinpaprika/coinpaprika-api-nodejs-client/master.svg" alt="Travis CI Build Status" /></a></span>
+<span class="badge-githubactions"><a href="https://github.com/coinpaprika/coinpaprika-api-nodejs-client/actions/workflows/ci.yml" title="Check this project's build status on GitHub Actions"><img src="https://github.com/coinpaprika/coinpaprika-api-nodejs-client/actions/workflows/ci.yml/badge.svg" alt="CI Build Status" /></a></span>
 <span class="badge-npmdownloads"><a href="https://www.npmjs.com/package/@coinpaprika/api-nodejs-client" title="View this project on NPM"><img src="https://img.shields.io/npm/dm/@coinpaprika/api-nodejs-client.svg" alt="NPM downloads" /></a></span>
 <span class="badge-npmlicence"><a href="https://www.npmjs.com/package/@coinpaprika/api-nodejs-client" title="View this project on NPM"><img src="https://img.shields.io/npm/l/@coinpaprika/api-nodejs-client.svg" alt="NPM downloads" /></a></span>
 <span class="badge-daviddm"><a href="https://david-dm.org/coinpaprika/coinpaprika-api-nodejs-client" title="View the status of this project's dependencies on DavidDM"><img src="https://david-dm.org/googleapis/google-api-nodejs-client.svg" alt="Dependency Status" /></a></span>


### PR DESCRIPTION
## Problem

The README carries a Travis CI badge. travis-ci.org was shut down for open-source projects in 2021, so the badge is dead — it renders **`404 badge not found`** to everyone who opens the README.

Verified:

```
$ curl -s "https://img.shields.io/travis/coinpaprika/coinpaprika-api-nodejs-client/master.svg" \
    | grep -o '<text[^>]*>[^<]*</text>'
404 badge not found
```

There is a second, independent bug in the same line: the badge's link pointed at `http://travis-ci.org/bevry/badges` — the badge generator's own repository — not at this project's builds. So even before the shutdown it sent readers to the wrong place.

## Fix

Replaced it with the badge for the existing `CI` workflow (`.github/workflows/ci.yml`), keeping the surrounding `<span class="badge-…">` markup the other badges use.

Verified the replacement renders correctly, and that CI is genuinely green on `master`:

```
$ curl -s ".../actions/workflows/ci.yml/badge.svg" | grep '<title>'
<title>CI - passing</title>
```

## Out of scope, but worth a look

Line 7 has the same class of problem and I left it alone deliberately:

```html
<span class="badge-daviddm"><a href="https://david-dm.org/coinpaprika/coinpaprika-api-nodejs-client" ...>
  <img src="https://david-dm.org/googleapis/google-api-nodejs-client.svg" alt="Dependency Status" /></a></span>
```

david-dm.org is also dead — that URL returns HTTP 500, so it renders as a broken image. And the image points at **`googleapis/google-api-nodejs-client`**, a different project entirely, so even when the service was alive this badge reported Google's dependency status rather than ours.

Happy to remove it in a follow-up, or fold it into this PR if preferred.